### PR TITLE
Add failing tests: Showing whitespaces removed from TextNode

### DIFF
--- a/src/Parser.fs
+++ b/src/Parser.fs
@@ -168,16 +168,6 @@ module Parser =
         |> Parsimmon.map (fun (tagName, attrs, _) -> tagName, attrs)
 
     let textSnippet =
-        let acceptableChars =
-            ['a' .. 'z']
-            |> List.append ['A' .. 'Z']
-            |> List.map string
-            |> String.concat ""
-            |> (+) "0123456789 "
-            |> (+) "-+,,!.@#$%^&*()~[]{}:?;"
-            |> Seq.toList
-            |> List.map string
-
         Parsimmon.satisfy (fun token -> token <> "<" && token <> ">")
         |> Parsimmon.atLeastOneOrMany
         |> Parsimmon.concat


### PR DESCRIPTION
Whitespaces are significant whent working with text we should keep this information and store it in the content value.

In the case of HTML, or an xml used for translation the whitespace are important to join correctly the sentence.

@Zaid-Ajaj Since this morning, I am trying to make the tests goes green but I can't succeed. The problem come from using `withWhitespace` on the open/close node. 

For example: `(withWhitespace (Parsimmon.str ">"))` with eat all the space before and **after** the `>` char and that's a problem. We want to keep them.

Or perhaps, this is not compatible with standard XML and I need to build a specific parser for HTML